### PR TITLE
Adding auth option

### DIFF
--- a/pymultitor.py
+++ b/pymultitor.py
@@ -200,9 +200,10 @@ class MultiTorProxy(Master):
             'listen_port': listen_port,
             'ssl_insecure': self.insecure,
             'mode': "socks5" if socks else "regular",
-            'rawtcp': False
+            'rawtcp': False,
+            'auth_singleuser': auth
         }
-        options_dict['proxyauth' if new_mitmproxy else 'auth_singleuser'] = auth
+        # options_dict['proxyauth' if new_mitmproxy else 'auth_singleuser'] = auth
 
         options = ProxyOptions(**options_dict)
 


### PR DESCRIPTION
I've added the authentication option for authenticate proxy users. When it's setted, it's neccesary to provide a username and a password with *BasicAuth*. 

For running the proxy:

```
junquera@opa:~/pymultitor$ python pymultitor.py -a 'user:pass'
14-11-17 23:29:43 WARNING  Change IP Configuration Not Set (Acting As Regular Tor Proxy)
14-11-17 23:29:43 INFO     Executing 2 Tor Processes
```

For using it:

```
junquera@opa:~$ export http_proxy=http://user:pass@127.0.0.1:8080
```

I've added the option like `mitmproxy` does, taking into account the `new_mitmproxy` "flag"  because in `< 0.18.3`  the arg name is `auth_singleuser` and in newer versions is `proxyauth` (that's the reason I have needed to write `ProxyOptions` as a `dict`).