### PR TITLE
Fixed script to not change identity on every request

### DIFF
--- a/pymultitor.py
+++ b/pymultitor.py
@@ -341,7 +341,7 @@ class PyMultiTor(object):
             flow.response = self.create_response(flow.request)
 
         # If Counter Raised To The Configured Number
-        if 0 < next(self.counter) >= self.on_count:
+        if self.on_count and next(self.counter) >= self.on_count:
             self.logger.debug("Counter Raised To The Configured Number")
             self.counter = itertools.count(1)
             self.multitor.new_identity()


### PR DESCRIPTION
The default value if `--on-count` is missing is zero. In this case, the identity will change on every request.

Now I understand all those `Cant Change Tor Identity (Need More Tor Processes)` warnings when I was running this for like three days. Maybe it would be quicker with this fix :)