### PR TITLE
Print "Changing Tor Identity" as info (not debug)

### DIFF
--- a/pymultitor.py
+++ b/pymultitor.py
@@ -91,7 +91,7 @@ class Tor(object):
             self.logger.warning("[%05d] Cant Change Tor Identity (Need More Tor Processes)" % self.id)
             return False
 
-        self.logger.debug("[%05d] Changing Tor Identity" % self.id)
+        self.logger.info("[%05d] Changing Tor Identity" % self.id)
         self.controller.signal(Signal.NEWNYM)
         return True
 


### PR DESCRIPTION
It's an essential piece of information. And it shouldn't be too common.