### PR TITLE
Allow to disable tor timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ options:
   -e CONFIG, --tor-config CONFIG
                         tor extended json configuration (default: {})
   -t TIMEOUT, --tor-timeout TIMEOUT
-                        number of seconds before our attempt to start a tor instance timed out (default: 90)
+                        timeout in seconds for starting a tor instance; 0 disables timeout (default: 90)
   -r TRIES, --tor-tries TRIES
                         number tries to start a tor instance before it fails (default: 5)
   --on-count ON_COUNT   change ip every x requests (resources also counted) (default: 0)

--- a/pymultitor.py
+++ b/pymultitor.py
@@ -94,7 +94,7 @@ class Tor(object):
                         **self.tor_config
                     },
                     tor_cmd=self.tor_cmd,
-                    timeout=self.tor_timeout,
+                    timeout=self.tor_timeout if self.tor_timeout != 0 else None,
                     init_msg_handler=self.print_bootstrapped_line
                 )
                 break
@@ -281,7 +281,7 @@ class PyMultiTor(object):
             name="tor_timeout",
             typespec=int,
             default=DEFAULT_INIT_TIMEOUT,
-            help="number of seconds before our attempt to start a tor instance timed out",
+            help="timeout in seconds for starting a tor instance; 0 disables timeout",
         )
         loader.add_option(
             name="tor_tries",
@@ -490,7 +490,7 @@ def main(args=None):
                         dest="config",
                         default="{}")
     parser.add_argument("-t", "--tor-timeout",
-                        help="number of seconds before our attempt to start a tor instance timed out",
+                        help="timeout in seconds for starting a tor instance; 0 disables timeout",
                         dest="timeout",
                         type=int,
                         default=DEFAULT_INIT_TIMEOUT)


### PR DESCRIPTION
According to the documentation:
> **timeout** _(int)_ -- time after which the attempt to start tor is aborted, no timeouts are applied if **None**

https://stem.torproject.org/api/process.html